### PR TITLE
Fix build on stable rust

### DIFF
--- a/examples/json.rs
+++ b/examples/json.rs
@@ -1,5 +1,5 @@
 extern crate pom;
-use pom::{Parser, DataInput};
+use pom::DataInput;
 use pom::char_class::hex_digit;
 use pom::parser::*;
 
@@ -17,11 +17,11 @@ pub enum JsonValue {
 	Object(HashMap<String,JsonValue>)
 }
 
-fn space() -> Parser<u8, ()> {
+fn space() -> Parser<'static, u8, ()> {
 	one_of(b" \t\r\n").repeat(0..).discard()
 }
 
-fn number() -> Parser<u8, f64> {
+fn number() -> Parser<'static, u8, f64> {
 	let integer = one_of(b"123456789") - one_of(b"0123456789").repeat(0..) | sym(b'0');
 	let frac = sym(b'.') + one_of(b"0123456789").repeat(1..);
 	let exp = one_of(b"eE") + one_of(b"+-").opt() + one_of(b"0123456789").repeat(1..);
@@ -29,7 +29,7 @@ fn number() -> Parser<u8, f64> {
 	number.collect().convert(|v|String::from_utf8(v)).convert(|s|f64::from_str(&s))
 }
 
-fn string() -> Parser<u8, String> {
+fn string() -> Parser<'static, u8, String> {
 	let special_char = sym(b'\\') | sym(b'/') | sym(b'"')
 		| sym(b'b').map(|_|b'\x08') | sym(b'f').map(|_|b'\x0C')
 		| sym(b'n').map(|_|b'\n') | sym(b'r').map(|_|b'\r') | sym(b't').map(|_|b'\t');
@@ -41,19 +41,19 @@ fn string() -> Parser<u8, String> {
 	string.map(|strings|strings.concat())
 }
 
-fn array() -> Parser<u8, Vec<JsonValue>> {
+fn array() -> Parser<'static, u8, Vec<JsonValue>> {
 	let elems = list(call(value), sym(b',') * space());
 	sym(b'[') * space() * elems - sym(b']')
 }
 
-fn object() -> Parser<u8, HashMap<String, JsonValue>> {
+fn object() -> Parser<'static, u8, HashMap<String, JsonValue>> {
 	let member = string() - space() - sym(b':') - space() + call(value);
 	let members = list(member, sym(b',') * space());
 	let obj = sym(b'{') * space() * members - sym(b'}');
 	obj.map(|members|members.into_iter().collect::<HashMap<_,_>>())
 }
 
-fn value() -> Parser<u8, JsonValue> {
+fn value() -> Parser<'static, u8, JsonValue> {
 	( seq(b"null").map(|_|JsonValue::Null)
 	| seq(b"true").map(|_|JsonValue::Bool(true))
 	| seq(b"false").map(|_|JsonValue::Bool(false))
@@ -64,7 +64,7 @@ fn value() -> Parser<u8, JsonValue> {
 	) - space()
 }
 
-pub fn json() -> Parser<u8, JsonValue> {
+pub fn json() -> Parser<'static, u8, JsonValue> {
 	space() * value() - end()
 }
 

--- a/examples/json_char.rs
+++ b/examples/json_char.rs
@@ -1,5 +1,5 @@
 extern crate pom;
-use pom::{Parser, TextInput};
+use pom::TextInput;
 use pom::parser::*;
 
 use std::str::FromStr;
@@ -17,11 +17,11 @@ pub enum JsonValue {
 	Object(HashMap<String,JsonValue>)
 }
 
-fn space() -> Parser<char, ()> {
+fn space() -> Parser<'static, char, ()> {
 	one_of(" \t\r\n").repeat(0..).discard()
 }
 
-fn number() -> Parser<char, f64> {
+fn number() -> Parser<'static, char, f64> {
 	let integer = one_of("123456789") - one_of("0123456789").repeat(0..) | sym('0');
 	let frac = sym('.') + one_of("0123456789").repeat(1..);
 	let exp = one_of("eE") + one_of("+-").opt() + one_of("0123456789").repeat(1..);
@@ -29,7 +29,7 @@ fn number() -> Parser<char, f64> {
 	number.collect().map(|v|String::from_iter(v)).convert(|s|f64::from_str(&s))
 }
 
-fn string() -> Parser<char, String> {
+fn string() -> Parser<'static, char, String> {
 	let special_char = sym('\\') | sym('/') | sym('"')
 		| sym('b').map(|_|'\x08') | sym('f').map(|_|'\x0C')
 		| sym('n').map(|_|'\n') | sym('r').map(|_|'\r') | sym('t').map(|_|'\t');
@@ -41,19 +41,19 @@ fn string() -> Parser<char, String> {
 	string.map(|strings|strings.concat())
 }
 
-fn array() -> Parser<char, Vec<JsonValue>> {
+fn array() -> Parser<'static, char, Vec<JsonValue>> {
 	let elems = list(call(value), sym(',') * space());
 	sym('[') * space() * elems - sym(']')
 }
 
-fn object() -> Parser<char, HashMap<String, JsonValue>> {
+fn object() -> Parser<'static, char, HashMap<String, JsonValue>> {
 	let member = string() - space() - sym(':') - space() + call(value);
 	let members = list(member, sym(',') * space());
 	let obj = sym('{') * space() * members - sym('}');
 	obj.map(|members|members.into_iter().collect::<HashMap<_,_>>())
 }
 
-fn value() -> Parser<char, JsonValue> {
+fn value() -> Parser<'static, char, JsonValue> {
 	( seq("null").map(|_|JsonValue::Null)
 	| seq("true").map(|_|JsonValue::Bool(true))
 	| seq("false").map(|_|JsonValue::Bool(false))
@@ -64,7 +64,7 @@ fn value() -> Parser<char, JsonValue> {
 	) - space()
 }
 
-pub fn json() -> Parser<char, JsonValue> {
+pub fn json() -> Parser<'static, char, JsonValue> {
 	space() * value() - end()
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,3 @@
-#![feature(loop_break_value)]
-#![feature(collections_range)]
-#![feature(collections_bound)]
-
 mod input;
 mod result;
 mod train;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,8 +1,39 @@
 use std::fmt::{Display, Debug};
 use std::ops::{Add, Sub, Mul, Shr, BitOr, Neg, Not};
-use std::collections::range::RangeArgument;
-use std::collections::Bound::{Excluded, Included, Unbounded};
+use std::ops::{Range, RangeFrom, RangeTo, RangeFull};
 use super::{Result, Error, Input, Train};
+
+pub enum Bound<'a, T: 'a> {
+	Excluded(&'a T),
+	Included(&'a T),
+	Unbounded,
+}
+use self::Bound::*;
+
+pub trait RangeArgument<T> {
+	fn start(&self) -> Bound<T>;
+	fn end(&self) -> Bound<T>;
+}
+
+impl<T> RangeArgument<T> for Range<T> {
+	fn start(&self) -> Bound<T> { Included(&self.start) }
+	fn end(&self) -> Bound<T> { Excluded(&self.end) }
+}
+
+impl<T> RangeArgument<T> for RangeFrom<T> {
+	fn start(&self) -> Bound<T> { Included(&self.start) }
+	fn end(&self) -> Bound<T> { Unbounded }
+}
+
+impl<T> RangeArgument<T> for RangeTo<T> {
+	fn start(&self) -> Bound<T> { Unbounded }
+	fn end(&self) -> Bound<T> { Excluded(&self.end) }
+}
+
+impl<T> RangeArgument<T> for RangeFull {
+	fn start(&self) -> Bound<T> { Unbounded }
+	fn end(&self) -> Bound<T> { Unbounded }
+}
 
 /// Parser combinator.
 pub struct Parser<'a, I, O> {
@@ -187,29 +218,34 @@ pub fn sym<'a, I>(t: I) -> Parser<'a, I, I>
 }
 
 /// Sucess when sequence of symbols match current input.
-pub fn seq<'a, I, T>(train: &'static T) -> Parser<'a, I, Vec<I>>
+pub fn seq<'a, I, T: ?Sized>(train: &'static T) -> Parser<'a, I, Vec<I>>
 	where I: Copy + PartialEq + Display + 'static,
-		  T: Train<I> + ?Sized
+		  T: Train<I>
 {
 	Parser::new(move |input: &mut Input<I>| {
 		let tag = train.knots();
 		let start = input.position();
 		let mut index = 0;
-		let result = loop {
+		let result;
+
+		loop {
 			if index == tag.len() {
-				break Ok(tag);
+				result = Ok(tag);
+				break;
 			}
 			if let Some(s) = input.current() {
 				if tag[index] == s {
 					input.advance();
 				} else {
-					break Err(Error::Mismatch {
+					result = Err(Error::Mismatch {
 						message: format!("seq {} expect: {}, found: {}", train.to_str(), tag[index], s),
 						position: input.position(),
 					});
+					break;
 				}
 			} else {
-				break Err(Error::Incomplete);
+				result = Err(Error::Incomplete);
+				break;
 			}
 			index += 1;
 		};
@@ -247,9 +283,9 @@ pub fn list<'a, I, O, U>(parser: Parser<'a, I, O>, separator: Parser<'a, I, U>) 
 }
 
 /// Sucess when current input symbol is one of the set.
-pub fn one_of<'a, I, T>(train: &'static T) -> Parser<'a, I, I>
+pub fn one_of<'a, I, T: ?Sized>(train: &'static T) -> Parser<'a, I, I>
 	where I: Copy + PartialEq + Display + Debug + 'static,
-		  T: Train<I> + ?Sized
+		  T: Train<I>
 {
 	Parser::new(move |input: &mut Input<I>| {
 		if let Some(s) = input.current() {
@@ -270,9 +306,9 @@ pub fn one_of<'a, I, T>(train: &'static T) -> Parser<'a, I, I>
 }
 
 /// Sucess when current input symbol is none of the set.
-pub fn none_of<'a, I, T>(train: &'static T) -> Parser<'a, I, I>
+pub fn none_of<'a, I, T: ?Sized>(train: &'static T) -> Parser<'a, I, I>
 	where I: Copy + PartialEq + Display + Debug + 'static,
-		  T: Train<I> + ?Sized
+		  T: Train<I>
 {
 	Parser::new(move |input: &mut Input<I>| {
 		if let Some(s) = input.current() {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -597,6 +597,7 @@ impl<'a, I: Copy + 'static, O: 'static> Not for Parser<'a, I, O> {
 mod tests {
 	use ::parser::*;
 	use ::{DataInput, TextInput};
+	use ::{Error, Input};
 
 	#[test]
 	fn byte_works() {

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -1,17 +1,17 @@
 extern crate pom;
 
-use pom::{Parser, DataInput};
+use pom::DataInput;
 use pom::parser::*;
 
-fn spaces() -> Parser<u8, ()> {
+fn spaces() -> Parser<'static, u8, ()> {
 	one_of(b" ").repeat(1..).discard()
 }
 
-fn works() -> Parser<u8, Vec<u8>> {
+fn works() -> Parser<'static, u8, Vec<u8>> {
 	list(one_of(b"abc"), spaces() * seq(b"and") - spaces())
 }
 
-fn dangle() -> Parser<u8, (Vec<u8>, Vec<u8>)> {
+fn dangle() -> Parser<'static, u8, (Vec<u8>, Vec<u8>)> {
 	list(one_of(b"abc"), spaces() * seq(b"and") - spaces()) + seq(b" and")
 }
 


### PR DESCRIPTION
This fixes three issues that prevent pom from compiling with stable Rust:
- Fix the use of `?Sized` so that it compiles
- Avoid "loops with values"
- Implement a local `RangeArgument` trait for the `Range*` operators

There's still some differences between nightly and stable relating to a conflict over
`::Parser` and `::parser::Parser` - in stable the `use parser::*` causes a duplicate
import issue. I haven't found a completely clean fix for this yet.

Addresses #6 