### PR TITLE
Remove unnecessary trait bounds.

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5,7 +5,7 @@ use crate::set::Set;
 use std::fmt::{Debug, Display};
 use std::ops::{Add, BitOr, Mul, Neg, Not, Shr, Sub};
 
-type Parse<'a, I, O> = Fn(&'a [I], usize) -> Result<(O, usize)> + 'a;
+type Parse<'a, I, O> = dyn Fn(&'a [I], usize) -> Result<(O, usize)> + 'a;
 
 /// Parser combinator.
 pub struct Parser<'a, I, O> {


### PR DESCRIPTION
These changes mainly remove unnecessary trait bounds and change `Copy` to `Clone` where making a copy is necessary.

Note that it is possible to remove the need for `Clone` entirely by changing the output type of certain functions to references rather than values, and changing the predicate functions to take a reference. However those would be breaking changes, so I left it at these compatible changes for now.

For kicks I did try making those other changes above, and the changes themselves are easy to make, but changing all the tests to compare correctly is a bit more involved. Also worth noting is that if you were to make those changes to return references, it would be very convenient to provide something like:
```rust
impl<'a, I, O: Clone> Parser<'a, I, &'a O> {
    pub fn cloned(self) -> Parser<'a, I, O> {
        self.map(|v| v.clone())
    }
}
```