### PR TITLE
Remove more unnecessary traits and generalize PartialEq usage

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -220,11 +220,12 @@ pub fn empty<'a, I>() -> Parser<'a, I, ()> {
 }
 
 /// Success when current input symbol equals `t`.
-pub fn sym<'a, I>(t: I) -> Parser<'a, I, I>
+pub fn sym<'a, T, I>(t: I) -> Parser<'a, T, T>
 where
-	I: Clone + PartialEq + Display,
+	I: PartialEq<T> + Display + 'a,
+	T: Clone + Display
 {
-	Parser::new(move |input: &'a [I], start: usize| {
+	Parser::new(move |input: &'a [T], start: usize| {
 		if let Some(s) = input.get(start) {
 			if t == *s {
 				Ok((s.clone(), start + 1))
@@ -241,11 +242,12 @@ where
 }
 
 /// Success when sequence of symbols matches current input.
-pub fn seq<'a, 'b: 'a, I>(tag: &'b [I]) -> Parser<'a, I, &'a [I]>
+pub fn seq<'a, 'b: 'a, T, I>(tag: &'b [I]) -> Parser<'a, T, &'a [I]>
 where
-	I: PartialEq + Debug,
+	I: PartialEq<T> + Display + Debug,
+	T: Display
 {
-	Parser::new(move |input: &'a [I], start: usize| {
+	Parser::new(move |input: &'a [T], start: usize| {
 		let mut index = 0;
 		loop {
 			let pos = start + index;
@@ -255,7 +257,7 @@ where
 			if let Some(s) = input.get(pos) {
 				if tag[index] != *s {
 					return Err(Error::Mismatch {
-						message: format!("seq {:?} expect: {:?}, found: {:?}", tag, tag[index], s),
+						message: format!("seq {:?} expect: {}, found: {}", tag, tag[index], s),
 						position: pos,
 					});
 				}
@@ -320,7 +322,7 @@ where
 /// Success when current input symbol is one of the set.
 pub fn one_of<'a, I, S>(set: &'a S) -> Parser<'a, I, I>
 where
-	I: Clone + PartialEq + Display + Debug,
+	I: Clone + Display,
 	S: Set<I> + ?Sized,
 {
 	Parser::new(move |input: &'a [I], start: usize| {
@@ -342,7 +344,7 @@ where
 /// Success when current input symbol is none of the set.
 pub fn none_of<'a, I, S>(set: &'static S) -> Parser<'a, I, I>
 where
-	I: Clone + PartialEq + Display + Debug,
+	I: Clone + Display,
 	S: Set<I> + ?Sized,
 {
 	Parser::new(move |input: &'a [I], start: usize| {
@@ -364,7 +366,7 @@ where
 /// Success when predicate returns true on current input symbol.
 pub fn is_a<'a, I, F>(predicate: F) -> Parser<'a, I, I>
 where
-	I: Clone + PartialEq + Display + Debug,
+	I: Clone + Display,
 	F: Fn(I) -> bool + 'a,
 {
 	Parser::new(move |input: &'a [I], start: usize| {
@@ -386,7 +388,7 @@ where
 /// Success when predicate returns false on current input symbol.
 pub fn not_a<'a, I, F>(predicate: F) -> Parser<'a, I, I>
 where
-	I: Clone + PartialEq + Display + Debug,
+	I: Clone + Display,
 	F: Fn(I) -> bool + 'a,
 {
 	Parser::new(move |input: &'a [I], start: usize| {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -320,12 +320,12 @@ where
 }
 
 /// Success when current input symbol is one of the set.
-pub fn one_of<'a, I, S>(set: &'a S) -> Parser<'a, I, I>
+pub fn one_of<'a, T, I, S>(set: &'a S) -> Parser<'a, T, T>
 where
-	I: Clone + Display,
-	S: Set<I> + ?Sized,
+	T: Clone + Display,
+	S: Set<I,T> + ?Sized,
 {
-	Parser::new(move |input: &'a [I], start: usize| {
+	Parser::new(move |input: &'a [T], start: usize| {
 		if let Some(s) = input.get(start) {
 			if set.contains(s) {
 				Ok((s.clone(), start + 1))
@@ -342,12 +342,12 @@ where
 }
 
 /// Success when current input symbol is none of the set.
-pub fn none_of<'a, I, S>(set: &'static S) -> Parser<'a, I, I>
+pub fn none_of<'a, T, I, S>(set: &'static S) -> Parser<'a, T, T>
 where
-	I: Clone + Display,
-	S: Set<I> + ?Sized,
+	T: Clone + Display,
+	S: Set<I,T> + ?Sized,
 {
-	Parser::new(move |input: &'a [I], start: usize| {
+	Parser::new(move |input: &'a [T], start: usize| {
 		if let Some(s) = input.get(start) {
 			if set.contains(s) {
 				Err(Error::Mismatch {


### PR DESCRIPTION
These changes remove some unnecessary trait restrictions on the functions, and also generalize all uses of `PartialEq` (including the set implementation) to arbitrary types implementing `PartialEq<T>`. I think in most cases this introduces no breaking changes (and all tests still run and pass as before), however a larger corpus or test base may better confirm this. The only thing that makes me less sure is things like the change to `sym` which cause the returned parser to be a different type than types that are inferred from input arguments (i.e., the output type now is inferred from usage rather than from arguments, so it may be the case that existing code will need annotations to disambiguate). So to be safe it may be appropriate to put this toward a breaking API release.