### PR TITLE
Amend RangeArgument such that repeat accepts RangeToInclusive and RangeInclusive

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -707,6 +707,41 @@ mod tests {
 	}
 
 	#[test]
+	fn repeat_up_to_inclusive() {
+		let input = b"xxxooo";
+
+		{
+			let parser = sym(b'x').repeat(..=2);
+			let output = parser.parse(input);
+			assert_eq!(output, Ok(vec![b'x'; 2]))
+		}
+
+		{
+			let parser = sym(b'x').repeat(..=4);
+			let output = parser.parse(input);
+			assert_eq!(output, Ok(vec![b'x'; 3]))
+		}
+
+		{
+			let parser = sym(b'x').repeat(..);
+			let output = parser.parse(input);
+			assert_eq!(output, Ok(vec![b'x'; 3]))
+		}
+
+		{
+			let parser = sym(b'x').repeat(..=0);
+			let output = parser.parse(input);
+			assert_eq!(output, Ok(vec![]))
+		}
+
+		{
+			let parser = sym(b'x').repeat(..=10);
+			let output = parser.parse(input);
+			assert_eq!(output, Ok(vec![b'x'; 3]))
+		}
+	}
+
+	#[test]
 	fn repeat_exactly() {
 		let input = b"xxxooo";
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,11 +1,12 @@
 use super::{Error, Result};
 use crate::{
-	range::{Bound::*, RangeArgument},
+	range::RangeArgument,
 	set::Set,
 };
 use std::{
 	fmt::{Debug, Display},
 	ops::{Add, BitOr, Mul, Neg, Not, Shr, Sub},
+	ops::Bound::{Included, Excluded, Unbounded},
 };
 
 type Parse<'a, I, O> = dyn Fn(&'a [I], usize) -> Result<(O, usize)> + 'a;
@@ -723,12 +724,6 @@ mod tests {
 		}
 
 		{
-			let parser = sym(b'x').repeat(..);
-			let output = parser.parse(input);
-			assert_eq!(output, Ok(vec![b'x'; 3]))
-		}
-
-		{
 			let parser = sym(b'x').repeat(..=0);
 			let output = parser.parse(input);
 			assert_eq!(output, Ok(vec![]))
@@ -738,6 +733,41 @@ mod tests {
 			let parser = sym(b'x').repeat(..=10);
 			let output = parser.parse(input);
 			assert_eq!(output, Ok(vec![b'x'; 3]))
+		}
+	}
+
+	#[test]
+	fn repeat_from_to_inclusive() {
+		let input = b"xxxooo";
+
+		{
+			let parser = sym(b'x').repeat(1..=2);
+			let output = parser.parse(input);
+			assert_eq!(output, Ok(vec![b'x'; 2]))
+		}
+
+		{
+			let parser = sym(b'x').repeat(1..=4);
+			let output = parser.parse(input);
+			assert_eq!(output, Ok(vec![b'x'; 3]))
+		}
+
+		{
+			let parser = sym(b'x').repeat(0..=0);
+			let output = parser.parse(input);
+			assert_eq!(output, Ok(vec![]))
+		}
+
+		{
+			let parser = sym(b'x').repeat(3..=10);
+			let output = parser.parse(input);
+			assert_eq!(output, Ok(vec![b'x'; 3]))
+		}
+
+		{
+			let parser = sym(b'x').repeat(4..=10);
+			let output = parser.parse(input);
+			assert!(output.is_err())
 		}
 	}
 

--- a/src/range.rs
+++ b/src/range.rs
@@ -1,4 +1,4 @@
-use std::ops::{Range, RangeFrom, RangeFull, RangeTo};
+use std::ops::{Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
 
 pub enum Bound<'a, T: 'a> {
 	Excluded(&'a T),
@@ -30,6 +30,26 @@ impl<T> RangeArgument<T> for RangeFrom<T> {
 	}
 }
 
+impl<T> RangeArgument<T> for RangeFull {
+	fn start(&self) -> Bound<T> {
+		Unbounded
+	}
+	fn end(&self) -> Bound<T> {
+		Unbounded
+	}
+}
+
+// impl<T: Clone> RangeArgument<T> for RangeInclusive<T> {
+//     fn start(&self) -> Bound<T> {
+// 		let (start, _) = self.clone().into_inner();
+//         Included(&start.to_owned())
+//     }
+//     fn end(&self) -> Bound<T> {
+// 		let (_, end) = self.clone().into_inner();
+//         Included(&end.to_owned())
+//     }
+// }
+
 impl<T> RangeArgument<T> for RangeTo<T> {
 	fn start(&self) -> Bound<T> {
 		Unbounded
@@ -39,12 +59,12 @@ impl<T> RangeArgument<T> for RangeTo<T> {
 	}
 }
 
-impl<T> RangeArgument<T> for RangeFull {
+impl<T> RangeArgument<T> for RangeToInclusive<T> {
 	fn start(&self) -> Bound<T> {
 		Unbounded
 	}
 	fn end(&self) -> Bound<T> {
-		Unbounded
+		Included(&self.end)
 	}
 }
 

--- a/src/range.rs
+++ b/src/range.rs
@@ -1,4 +1,4 @@
-use std::ops::{Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
+use std::ops::{Range, RangeFrom, RangeFull, RangeTo, RangeToInclusive};
 
 pub enum Bound<'a, T: 'a> {
 	Excluded(&'a T),

--- a/src/range.rs
+++ b/src/range.rs
@@ -1,78 +1,117 @@
-use std::ops::{Range, RangeFrom, RangeFull, RangeTo, RangeToInclusive};
-
-pub enum Bound<'a, T: 'a> {
-	Excluded(&'a T),
-	Included(&'a T),
-	Unbounded,
-}
-use self::Bound::*;
+use std::ops::{Bound, RangeBounds, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
 
 pub trait RangeArgument<T> {
-	fn start(&self) -> Bound<T>;
-	fn end(&self) -> Bound<T>;
+	fn start(&self) -> Bound<&usize>;
+	fn end(&self) -> Bound<&usize>;
 }
 
-impl<T> RangeArgument<T> for Range<T> {
-	fn start(&self) -> Bound<T> {
-		Included(&self.start)
+impl<T> RangeArgument<T> for Range<usize> {
+	fn start(&self) -> Bound<&usize> {
+        self.start_bound()
 	}
-	fn end(&self) -> Bound<T> {
-		Excluded(&self.end)
+	fn end(&self) -> Bound<&usize> {
+        self.end_bound()
 	}
 }
 
-impl<T> RangeArgument<T> for RangeFrom<T> {
-	fn start(&self) -> Bound<T> {
-		Included(&self.start)
+impl<T> RangeArgument<T> for RangeFrom<usize> {
+	fn start(&self) -> Bound<&usize> {
+        self.start_bound()
 	}
-	fn end(&self) -> Bound<T> {
-		Unbounded
+	fn end(&self) -> Bound<&usize> {
+        self.end_bound()
 	}
 }
 
 impl<T> RangeArgument<T> for RangeFull {
-	fn start(&self) -> Bound<T> {
-		Unbounded
+	fn start(&self) -> Bound<&usize> {
+        self.start_bound()
 	}
-	fn end(&self) -> Bound<T> {
-		Unbounded
-	}
-}
-
-// impl<T: Clone> RangeArgument<T> for RangeInclusive<T> {
-//     fn start(&self) -> Bound<T> {
-// 		let (start, _) = self.clone().into_inner();
-//         Included(&start.to_owned())
-//     }
-//     fn end(&self) -> Bound<T> {
-// 		let (_, end) = self.clone().into_inner();
-//         Included(&end.to_owned())
-//     }
-// }
-
-impl<T> RangeArgument<T> for RangeTo<T> {
-	fn start(&self) -> Bound<T> {
-		Unbounded
-	}
-	fn end(&self) -> Bound<T> {
-		Excluded(&self.end)
+	fn end(&self) -> Bound<&usize> {
+        self.end_bound()
 	}
 }
 
-impl<T> RangeArgument<T> for RangeToInclusive<T> {
-	fn start(&self) -> Bound<T> {
-		Unbounded
+impl<T> RangeArgument<T> for RangeInclusive<usize> {
+    fn start(&self) -> Bound<&usize> {
+        self.start_bound()
+    }
+    fn end(&self) -> Bound<&usize> {
+        self.end_bound()
+    }
+}
+
+impl<T> RangeArgument<T> for RangeTo<usize> {
+	fn start(&self) -> Bound<&usize> {
+        self.start_bound()
 	}
-	fn end(&self) -> Bound<T> {
-		Included(&self.end)
+	fn end(&self) -> Bound<&usize> {
+        self.end_bound()
 	}
 }
 
-impl RangeArgument<usize> for usize {
-	fn start(&self) -> Bound<usize> {
-		Included(self)
+impl<T> RangeArgument<T> for RangeToInclusive<usize> {
+	fn start(&self) -> Bound<&usize> {
+        self.start_bound()
 	}
-	fn end(&self) -> Bound<usize> {
-		Included(self)
+	fn end(&self) -> Bound<&usize> {
+        self.end_bound()
 	}
+}
+
+impl RangeArgument<usize> for usize { 
+    fn start(&self) -> Bound<&usize> {
+        Bound::Included(self)
+    }
+    fn end(&self) -> Bound<&usize> {
+        Bound::Included(self)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn accept<T, R>(ra: R, expected: impl std::ops::RangeBounds<usize>)
+    where
+        R: RangeArgument<T>,
+        T: std::fmt::Debug + std::cmp::PartialEq {
+        assert_eq!(ra.start(), expected.start_bound());
+        assert_eq!(ra.end(), expected.end_bound());
+    }
+
+    #[test]
+    fn unbounded() {
+        accept::<usize, _>(.., ..)
+    }
+
+    #[test]
+    fn up_to_inclusive() {
+        accept::<usize, _>(..=2, ..=2)
+    }
+
+    #[test]
+    fn up_to_exclusive() {
+        accept::<usize, _>(..2, ..2)
+    }
+
+    #[test]
+    fn from() {
+        accept::<usize, _>(1.., 1..)
+    }
+
+    #[test]
+    fn from_to_inclusive() {
+        accept::<usize, _>(1..=2, 1..=2)
+    }
+
+    #[test]
+    fn from_to_exclusive() {
+        accept::<usize, _>(1..3, 1..3)
+    }
+
+    #[test]
+    fn exactly() {
+        accept::<usize, _>(42, 42..=42)
+    }
 }


### PR DESCRIPTION
The `range.rs` file is amended so that both `RangeToInclusive` and `RangeInclusive` can be accepted as arguments to the `Parser::repeat` method.

This implementation no longer requires the `range.rs` implementation of `Bound`. Given that `Bound` was public this may be considered a breaking change and the version bumped up accordlingly.  Note: I did not update the version in `Cargo.toml`.

Also - I can see from https://github.com/J-F-Liu/pom/issues/58 that Range may not always be applicable as `usize` only. I've taken it as a "private" implementation, only to be used in `repeat()` calls, so we may need further discussion before this PR can be completed...