### PR TITLE
Feature/utility updates

### DIFF
--- a/doc/article.md
+++ b/doc/article.md
@@ -358,7 +358,7 @@ These are functions to create basic parsers.
 | -p                 | Success when p success, doen't consume input. |
 | !p                 | Success when p fail, doen't consume input. |
 | p.opt()            | Make parser optional.                    |
-| p.repeat(m..n)     | `p.repeat(0..)` repeat p zero or more times<br>`p.repeat(1..)` repeat p one or more times<br>`p.repeat(1..4)` match p at least 1 and at most 3 times |
+| p.repeat(m..n)     | `p.repeat(0..)` repeat p zero or more times<br>`p.repeat(1..)` repeat p one or more times<br>`p.repeat(1..4)` match p at least 1 and at most 3 times<br>`p.repeat(1..=3)` also match p at least 1 and at most 3 times |
 | p.map(f)           | Convert parser result to desired value.  |
 | p.convert(f)       | Convert parser result to desired value, fail in case of conversion error. |
 | p.pos()            | Get input position after matching p.     |

--- a/src/char_class.rs
+++ b/src/char_class.rs
@@ -4,6 +4,18 @@ pub fn alpha(term: u8) -> bool {
 	term.is_ascii_alphabetic()
 }
 
+/// Recognises an alphabetic character, `A-Z`.
+#[inline]
+pub fn alpha_uppercase(term: u8) -> bool {
+	term.is_ascii_uppercase()
+}
+
+/// Recognises an alphabetic character, `a-z`.
+#[inline]
+pub fn alpha_lowercase(term: u8) -> bool {
+	term.is_ascii_lowercase()
+}
+
 /// Recognises a decimal digit, `0-9`.
 #[inline]
 pub fn digit(term: u8) -> bool {
@@ -38,4 +50,86 @@ pub fn space(term: u8) -> bool {
 #[inline]
 pub fn multispace(term: u8) -> bool {
 	space(term) || matches!(term, b'\n' | b'\r')
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+
+	#[test]
+	fn is_an_alpha() {
+		assert!(alpha(b'A'));
+		assert!(alpha(b'Z'));
+		assert!(alpha(b'a'));
+		assert!(alpha(b'z'));
+	}
+
+	#[test]
+	fn is_an_alpha_uppercase() {
+		assert!(alpha_uppercase(b'A'));
+		assert!(alpha_uppercase(b'Z'));
+		assert!(!alpha_uppercase(b'a'));
+		assert!(!alpha_uppercase(b'z'));
+	}
+
+	#[test]
+	fn is_an_alpha_lowercase() {
+		assert!(!alpha_lowercase(b'A'));
+		assert!(!alpha_lowercase(b'Z'));
+		assert!(alpha_lowercase(b'a'));
+		assert!(alpha_lowercase(b'z'));
+	}
+
+	#[test]
+	fn is_a_digit() {
+		assert!(digit(b'0'));
+		assert!(digit(b'9'));
+		assert!(!digit(b'A'));
+	}
+
+	#[test]
+	fn is_an_alphanum() {
+		assert!(alphanum(b'A'));
+		assert!(alphanum(b'Z'));
+		assert!(alphanum(b'a'));
+		assert!(alphanum(b'z'));
+		assert!(alphanum(b'0'));
+		assert!(alphanum(b'9'));
+		assert!(!alphanum(b'#'));
+	}
+
+	#[test]
+	fn is_a_hex_digit() {
+		assert!(hex_digit(b'0'));
+		assert!(hex_digit(b'9'));
+		assert!(hex_digit(b'A'));
+		assert!(hex_digit(b'F'));
+		assert!(hex_digit(b'a'));
+		assert!(hex_digit(b'f'));
+		assert!(!hex_digit(b'G'));
+	}
+
+	#[test]
+	fn is_a_oct_digit() {
+		assert!(oct_digit(b'0'));
+		assert!(oct_digit(b'7'));
+		assert!(!oct_digit(b'8'));
+		assert!(!oct_digit(b'9'));
+	}
+
+	#[test]
+	fn is_space() {
+		assert!(space(b' '));
+		assert!(space(b'\t'));
+		assert!(!space(b'\n'));
+		assert!(!space(b'A'));
+	}
+
+	#[test]
+	fn is_multispace() {
+		assert!(multispace(b' '));
+		assert!(multispace(b'\t'));
+		assert!(multispace(b'\n'));
+		assert!(!multispace(b'A'));
+	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
-pub mod range;
+pub(crate) mod range;
 mod result;
-pub mod set;
+pub(crate) mod set;
 
 /// Contains predefined parsers and combinators.
 pub mod parser;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,11 +1,12 @@
 use super::{Error, Result};
 use crate::{
-	range::{Bound::*, RangeArgument},
+	range::RangeArgument,
 	set::Set,
 };
 use std::{
 	fmt::{Debug, Display},
 	ops::{Add, BitOr, Mul, Neg, Not, Shr, Sub},
+	ops::Bound::{Included, Excluded, Unbounded},
 };
 
 type Parse<'a, I, O> = dyn Fn(&'a [I], usize) -> Result<(O, usize)> + 'a;
@@ -754,12 +755,6 @@ mod tests {
 		}
 
 		{
-			let parser = sym(b'x').repeat(..);
-			let output = parser.parse(input);
-			assert_eq!(output, Ok(vec![b'x'; 3]))
-		}
-
-		{
 			let parser = sym(b'x').repeat(..=0);
 			let output = parser.parse(input);
 			assert_eq!(output, Ok(vec![]))
@@ -769,6 +764,41 @@ mod tests {
 			let parser = sym(b'x').repeat(..=10);
 			let output = parser.parse(input);
 			assert_eq!(output, Ok(vec![b'x'; 3]))
+		}
+	}
+
+	#[test]
+	fn repeat_from_to_inclusive() {
+		let input = b"xxxooo";
+
+		{
+			let parser = sym(b'x').repeat(1..=2);
+			let output = parser.parse(input);
+			assert_eq!(output, Ok(vec![b'x'; 2]))
+		}
+
+		{
+			let parser = sym(b'x').repeat(1..=4);
+			let output = parser.parse(input);
+			assert_eq!(output, Ok(vec![b'x'; 3]))
+		}
+
+		{
+			let parser = sym(b'x').repeat(0..=0);
+			let output = parser.parse(input);
+			assert_eq!(output, Ok(vec![]))
+		}
+
+		{
+			let parser = sym(b'x').repeat(3..=10);
+			let output = parser.parse(input);
+			assert_eq!(output, Ok(vec![b'x'; 3]))
+		}
+
+		{
+			let parser = sym(b'x').repeat(4..=10);
+			let output = parser.parse(input);
+			assert!(output.is_err())
 		}
 	}
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -738,6 +738,41 @@ mod tests {
 	}
 
 	#[test]
+	fn repeat_up_to_inclusive() {
+		let input = b"xxxooo";
+
+		{
+			let parser = sym(b'x').repeat(..=2);
+			let output = parser.parse(input);
+			assert_eq!(output, Ok(vec![b'x'; 2]))
+		}
+
+		{
+			let parser = sym(b'x').repeat(..=4);
+			let output = parser.parse(input);
+			assert_eq!(output, Ok(vec![b'x'; 3]))
+		}
+
+		{
+			let parser = sym(b'x').repeat(..);
+			let output = parser.parse(input);
+			assert_eq!(output, Ok(vec![b'x'; 3]))
+		}
+
+		{
+			let parser = sym(b'x').repeat(..=0);
+			let output = parser.parse(input);
+			assert_eq!(output, Ok(vec![]))
+		}
+
+		{
+			let parser = sym(b'x').repeat(..=10);
+			let output = parser.parse(input);
+			assert_eq!(output, Ok(vec![b'x'; 3]))
+		}
+	}
+
+	#[test]
 	fn repeat_exactly() {
 		let input = b"xxxooo";
 

--- a/src/range.rs
+++ b/src/range.rs
@@ -1,4 +1,4 @@
-use std::ops::{Range, RangeFrom, RangeFull, RangeTo};
+use std::ops::{Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
 
 pub enum Bound<'a, T: 'a> {
 	Excluded(&'a T),
@@ -30,6 +30,26 @@ impl<T> RangeArgument<T> for RangeFrom<T> {
 	}
 }
 
+impl<T> RangeArgument<T> for RangeFull {
+	fn start(&self) -> Bound<T> {
+		Unbounded
+	}
+	fn end(&self) -> Bound<T> {
+		Unbounded
+	}
+}
+
+// impl<T: Clone> RangeArgument<T> for RangeInclusive<T> {
+//     fn start(&self) -> Bound<T> {
+// 		let (start, _) = self.clone().into_inner();
+//         Included(&start.to_owned())
+//     }
+//     fn end(&self) -> Bound<T> {
+// 		let (_, end) = self.clone().into_inner();
+//         Included(&end.to_owned())
+//     }
+// }
+
 impl<T> RangeArgument<T> for RangeTo<T> {
 	fn start(&self) -> Bound<T> {
 		Unbounded
@@ -39,12 +59,12 @@ impl<T> RangeArgument<T> for RangeTo<T> {
 	}
 }
 
-impl<T> RangeArgument<T> for RangeFull {
+impl<T> RangeArgument<T> for RangeToInclusive<T> {
 	fn start(&self) -> Bound<T> {
 		Unbounded
 	}
 	fn end(&self) -> Bound<T> {
-		Unbounded
+		Included(&self.end)
 	}
 }
 

--- a/src/range.rs
+++ b/src/range.rs
@@ -1,4 +1,4 @@
-use std::ops::{Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
+use std::ops::{Range, RangeFrom, RangeFull, RangeTo, RangeToInclusive};
 
 pub enum Bound<'a, T: 'a> {
 	Excluded(&'a T),

--- a/src/range.rs
+++ b/src/range.rs
@@ -1,78 +1,117 @@
-use std::ops::{Range, RangeFrom, RangeFull, RangeTo, RangeToInclusive};
-
-pub enum Bound<'a, T: 'a> {
-	Excluded(&'a T),
-	Included(&'a T),
-	Unbounded,
-}
-use self::Bound::*;
+use std::ops::{Bound, RangeBounds, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
 
 pub trait RangeArgument<T> {
-	fn start(&self) -> Bound<T>;
-	fn end(&self) -> Bound<T>;
+	fn start(&self) -> Bound<&usize>;
+	fn end(&self) -> Bound<&usize>;
 }
 
-impl<T> RangeArgument<T> for Range<T> {
-	fn start(&self) -> Bound<T> {
-		Included(&self.start)
+impl<T> RangeArgument<T> for Range<usize> {
+	fn start(&self) -> Bound<&usize> {
+        self.start_bound()
 	}
-	fn end(&self) -> Bound<T> {
-		Excluded(&self.end)
+	fn end(&self) -> Bound<&usize> {
+        self.end_bound()
 	}
 }
 
-impl<T> RangeArgument<T> for RangeFrom<T> {
-	fn start(&self) -> Bound<T> {
-		Included(&self.start)
+impl<T> RangeArgument<T> for RangeFrom<usize> {
+	fn start(&self) -> Bound<&usize> {
+        self.start_bound()
 	}
-	fn end(&self) -> Bound<T> {
-		Unbounded
+	fn end(&self) -> Bound<&usize> {
+        self.end_bound()
 	}
 }
 
 impl<T> RangeArgument<T> for RangeFull {
-	fn start(&self) -> Bound<T> {
-		Unbounded
+	fn start(&self) -> Bound<&usize> {
+        self.start_bound()
 	}
-	fn end(&self) -> Bound<T> {
-		Unbounded
-	}
-}
-
-// impl<T: Clone> RangeArgument<T> for RangeInclusive<T> {
-//     fn start(&self) -> Bound<T> {
-// 		let (start, _) = self.clone().into_inner();
-//         Included(&start.to_owned())
-//     }
-//     fn end(&self) -> Bound<T> {
-// 		let (_, end) = self.clone().into_inner();
-//         Included(&end.to_owned())
-//     }
-// }
-
-impl<T> RangeArgument<T> for RangeTo<T> {
-	fn start(&self) -> Bound<T> {
-		Unbounded
-	}
-	fn end(&self) -> Bound<T> {
-		Excluded(&self.end)
+	fn end(&self) -> Bound<&usize> {
+        self.end_bound()
 	}
 }
 
-impl<T> RangeArgument<T> for RangeToInclusive<T> {
-	fn start(&self) -> Bound<T> {
-		Unbounded
+impl<T> RangeArgument<T> for RangeInclusive<usize> {
+    fn start(&self) -> Bound<&usize> {
+        self.start_bound()
+    }
+    fn end(&self) -> Bound<&usize> {
+        self.end_bound()
+    }
+}
+
+impl<T> RangeArgument<T> for RangeTo<usize> {
+	fn start(&self) -> Bound<&usize> {
+        self.start_bound()
 	}
-	fn end(&self) -> Bound<T> {
-		Included(&self.end)
+	fn end(&self) -> Bound<&usize> {
+        self.end_bound()
 	}
 }
 
-impl RangeArgument<usize> for usize {
-	fn start(&self) -> Bound<usize> {
-		Included(self)
+impl<T> RangeArgument<T> for RangeToInclusive<usize> {
+	fn start(&self) -> Bound<&usize> {
+        self.start_bound()
 	}
-	fn end(&self) -> Bound<usize> {
-		Included(self)
+	fn end(&self) -> Bound<&usize> {
+        self.end_bound()
 	}
+}
+
+impl RangeArgument<usize> for usize { 
+    fn start(&self) -> Bound<&usize> {
+        Bound::Included(self)
+    }
+    fn end(&self) -> Bound<&usize> {
+        Bound::Included(self)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn accept<T, R>(ra: R, expected: impl std::ops::RangeBounds<usize>)
+    where
+        R: RangeArgument<T>,
+        T: std::fmt::Debug + std::cmp::PartialEq {
+        assert_eq!(ra.start(), expected.start_bound());
+        assert_eq!(ra.end(), expected.end_bound());
+    }
+
+    #[test]
+    fn unbounded() {
+        accept::<usize, _>(.., ..)
+    }
+
+    #[test]
+    fn up_to_inclusive() {
+        accept::<usize, _>(..=2, ..=2)
+    }
+
+    #[test]
+    fn up_to_exclusive() {
+        accept::<usize, _>(..2, ..2)
+    }
+
+    #[test]
+    fn from() {
+        accept::<usize, _>(1.., 1..)
+    }
+
+    #[test]
+    fn from_to_inclusive() {
+        accept::<usize, _>(1..=2, 1..=2)
+    }
+
+    #[test]
+    fn from_to_exclusive() {
+        accept::<usize, _>(1..3, 1..3)
+    }
+
+    #[test]
+    fn exactly() {
+        accept::<usize, _>(42, 42..=42)
+    }
 }

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,6 +1,6 @@
 use std::{
 	cmp::{PartialEq, PartialOrd},
-	ops::{Range, RangeFrom, RangeFull, RangeTo},
+	ops::{Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive},
 	str,
 };
 
@@ -43,9 +43,21 @@ impl<T: PartialOrd + Copy> Set<T> for RangeFrom<T> {
 	}
 }
 
+impl<T: PartialOrd + Copy> Set<T> for RangeInclusive<T> {
+	fn contains(&self, elem: &T) -> bool {
+		self.start() <= elem && self.end() >= elem
+	}
+}
+
 impl<T: PartialOrd + Copy> Set<T> for RangeTo<T> {
 	fn contains(&self, elem: &T) -> bool {
 		self.end > *elem
+	}
+}
+
+impl<T: PartialOrd + Copy> Set<T> for RangeToInclusive<T> {
+	fn contains(&self, elem: &T) -> bool {
+		self.end >= *elem
 	}
 }
 
@@ -67,4 +79,51 @@ impl<const N: usize> Set<u8> for [u8; N] {
 	fn to_str(&self) -> &str {
 		str::from_utf8(self).unwrap_or("<byte array>")
 	}
+}
+
+#[cfg(test)]
+mod test {
+	use crate::parser::*;
+
+	#[test]
+	fn one_of_using_set() {
+		assert!(one_of(b"az").parse(b"a").is_ok());
+		assert!(one_of(b"az").parse(b"1").is_err());
+	}
+
+	#[test]
+	fn one_of_using_range() {
+		assert!(one_of(&(b'a'..b'z')).parse(b"a").is_ok());
+		assert!(one_of(&(b'a'..b'z')).parse(b"z").is_err());
+		assert!(one_of(&(b'a'..b'z')).parse(b"1").is_err());
+	}
+
+	#[test]
+	fn one_of_using_range_to() {
+		assert!(one_of(&(..b'z')).parse(b"a").is_ok());
+		assert!(one_of(&(..b'z')).parse(b"z").is_err());
+		assert!(one_of(&(..b'z')).parse(b"1").is_ok());
+	}
+
+	#[test]
+	fn one_of_using_range_inclusive() {
+		assert!(one_of(&(b'a'..=b'z')).parse(b"a").is_ok());
+		assert!(one_of(&(b'a'..=b'z')).parse(b"z").is_ok());
+		assert!(one_of(&(b'a'..=b'z')).parse(b"1").is_err());
+	}
+
+	#[test]
+	fn one_of_using_range_to_inclusive() {
+		assert!(one_of(&(..=b'z')).parse(b"a").is_ok());
+		assert!(one_of(&(..=b'z')).parse(b"z").is_ok());
+		assert!(one_of(&(..=b'z')).parse(b"1").is_ok());
+	}
+
+	#[test]
+	fn one_of_using_full_range() {
+		assert!(one_of(&(..)).parse(b"a").is_ok());
+		assert!(one_of(&(..)).parse(b"z").is_ok());
+		assert!(one_of(&(..)).parse(b"1").is_ok());
+	}
+
 }


### PR DESCRIPTION
Missing from the previous PR:

a) Added further utility functions to char_classes (+ trivial testing)
b) Amended set.rs to allow RangeToInclusive and RangeInclusive
c) Made range.rs and set.rs pub(crate) rather than pub; This is a big assumption that was the intention.

The last two changes are partly in response to issue https://github.com/J-F-Liu/pom/issues/58, and partly to align with the prior change for Range(To)Inclusive.

Look forward to the 3.4 release