### PR TITLE
Use eprintln instead of println for trace feature

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -205,14 +205,14 @@ impl<'a, I, O> Parser<'a, I, O> {
 	{
 		Parser::new(
 			move |input: &'a [I], start: usize| {
-				println!("parse: {} ({})", name, start);
+				eprintln!("parse: {} ({})", name, start);
 				match (self.method)(input, start) {
 					res @ Ok(_) => {
-						println!("       {} ({}): ok", name, start);
+						eprintln!("       {} ({}): ok", name, start);
 						res
 					},
 					Err(err) => {
-						println!("       {} ({}): error", name, start);
+						eprintln!("       {} ({}): error", name, start);
 						match err {
 							Error::Custom { .. } => Err(err),
 							_ => Err(Error::Custom {


### PR DESCRIPTION
This week I was using the trace feature. It is almost useful. Except…

My program is a TUI! :( So printing to STDOUT messes up the interface.

In my opinion it would make more sense for the trace feature to print to STDERR instead of STDOUT. That would enable things like running the file while using `2>` to redirect the logging to a file, so an interactive program can be used normally while still capturing the parser traces in another window.