### PR TITLE
Documentation & clippy warning removal.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pom"
-version = "3.4.0"
+version = "3.4.1"
 edition = "2021"
 authors = ["Junfeng Liu <china.liujunfeng@gmail.com>"]
 homepage = "https://github.com/J-F-Liu/pom"

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Aside from build issues (and the usual issues around error messages and debuggab
 | p.pos()            | Get input position after matching p.                                                                                                                                                           |
 | p.collect()        | Collect all matched input symbols.                                                                                                                                                             |
 | p.discard()        | Discard parser output.                                                                                                                                                                         |
-| p.name(\_)         | Give parser a name to identify parsing errors.<br>If the `trace` feature is enabled then a basic trace for the parse and parse result is made to stdout.                                       |
+| p.name(\_)         | Give parser a name to identify parsing errors.<br>If the `trace` feature is enabled then a basic trace for the parse and parse result is made to stderr.                                       |
 | p.expect(\_)       | Mark parser as expected, abort early when failed in ordered choice.                                                                                                                            |
 
 The choice of operators is established by their operator precedence, arity and "meaning".


### PR DESCRIPTION
1. Corrected README so that `trace` output is now going to stderr;

2. Removed `identity` mapping in Parser:: impl Mul.